### PR TITLE
Fix parsing of SecComponentSignature, SecServerSignature and SecWebAppId

### DIFF
--- a/src/parser/seclang-scanner.cc
+++ b/src/parser/seclang-scanner.cc
@@ -6252,19 +6252,19 @@ case 150:
 /* rule 150 can match eol */
 YY_RULE_SETUP
 #line 751 "seclang-scanner.ll"
-{ return p::make_CONFIG_COMPONENT_SIG(strchr(yytext, ' ') + 2, *driver.loc.back()); }
+{ return p::make_CONFIG_COMPONENT_SIG(parserSanitizer(find_separator(yytext)), *driver.loc.back()); }
 	YY_BREAK
 case 151:
 /* rule 151 can match eol */
 YY_RULE_SETUP
 #line 752 "seclang-scanner.ll"
-{ return p::make_CONFIG_SEC_SERVER_SIG(strchr(yytext, ' ') + 2, *driver.loc.back()); }
+{ return p::make_CONFIG_SEC_SERVER_SIG(parserSanitizer(find_separator(yytext)), *driver.loc.back()); }
 	YY_BREAK
 case 152:
 /* rule 152 can match eol */
 YY_RULE_SETUP
 #line 753 "seclang-scanner.ll"
-{ return p::make_CONFIG_SEC_WEB_APP_ID(parserSanitizer(strchr(yytext, ' ') + 2), *driver.loc.back()); }
+{ return p::make_CONFIG_SEC_WEB_APP_ID(parserSanitizer(find_separator(yytext)), *driver.loc.back()); }
 	YY_BREAK
 case 153:
 YY_RULE_SETUP

--- a/src/parser/seclang-scanner.ll
+++ b/src/parser/seclang-scanner.ll
@@ -747,9 +747,9 @@ EQUALS_MINUS                            (?i:=\-)
 . { BEGIN(INITIAL); }
 }
 
-{CONFIG_COMPONENT_SIG}[ \t]+["]{FREE_TEXT}["]                           { return p::make_CONFIG_COMPONENT_SIG(strchr(yytext, ' ') + 2, *driver.loc.back()); }
-{CONFIG_SEC_SERVER_SIG}[ \t]+["]{FREE_TEXT}["]                          { return p::make_CONFIG_SEC_SERVER_SIG(strchr(yytext, ' ') + 2, *driver.loc.back()); }
-{CONFIG_SEC_WEB_APP_ID}[ \t]+["]{FREE_TEXT}["]                          { return p::make_CONFIG_SEC_WEB_APP_ID(parserSanitizer(strchr(yytext, ' ') + 2), *driver.loc.back()); }
+{CONFIG_COMPONENT_SIG}[ \t]+["]{FREE_TEXT}["]                           { return p::make_CONFIG_COMPONENT_SIG(parserSanitizer(find_separator(yytext)), *driver.loc.back()); }
+{CONFIG_SEC_SERVER_SIG}[ \t]+["]{FREE_TEXT}["]                          { return p::make_CONFIG_SEC_SERVER_SIG(parserSanitizer(find_separator(yytext)), *driver.loc.back()); }
+{CONFIG_SEC_WEB_APP_ID}[ \t]+["]{FREE_TEXT}["]                          { return p::make_CONFIG_SEC_WEB_APP_ID(parserSanitizer(find_separator(yytext)), *driver.loc.back()); }
 {CONFIG_SEC_WEB_APP_ID}[ \t]+{FREE_TEXT_NEW_LINE}                       { return p::make_CONFIG_SEC_WEB_APP_ID(parserSanitizer(find_separator(yytext)), *driver.loc.back()); }
 {CONFIG_CONTENT_INJECTION}                                              { return p::make_CONFIG_CONTENT_INJECTION(*driver.loc.back()); }
 {CONFIG_DIR_AUDIT_DIR_MOD}[ \t]+{CONFIG_VALUE_NUMBER}                   { return p::make_CONFIG_DIR_AUDIT_DIR_MOD(parserSanitizer(find_separator(yytext)), *driver.loc.back()); }

--- a/test/test-cases/regression/auditlog.json
+++ b/test/test-cases/regression/auditlog.json
@@ -883,5 +883,45 @@
       "SecAuditLogFileMode 0600",
       "SecAuditLogType Serial"
     ]
+  },
+  {
+    "enabled": 1,
+    "version_min": 300000,
+    "version_max": 0,
+    "title": "auditlog : validate the SecComponentSignature value",
+    "client": {
+      "ip": "200.249.12.31",
+      "port": 2313
+    },
+    "server": {
+      "ip": "200.249.12.31",
+      "port": 80
+    },
+    "request": {
+      "headers": {
+        "Host": "www.modsecurity.org",
+        "Content-Length": "0"
+      },
+      "uri": "/index.php",
+      "method": "GET",
+      "http_version": 1.1,
+      "body": [
+        ""
+      ]
+    },
+    "expected": {
+      "audit_log": "[\"OWASP_CRS/4.25.0\"]",
+      "http_code": 200
+    },
+    "rules": [
+      "SecAuditEngine On",
+      "SecAuditLogFormat JSON",
+      "SecAuditLogParts ABCFHZ",
+      "SecComponentSignature \"OWASP_CRS/4.25.0\"",
+      "SecAuditLogDirMode 0766",
+      "SecAuditLogFileMode 0600",
+      "SecAuditLog /tmp/audit_component_signature.log",
+      "SecAuditLogType Serial"
+    ]
   }
 ]


### PR DESCRIPTION
Fix: https://github.com/owasp-modsecurity/ModSecurity-nginx/issues/365


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of component signature, server signature, and web application ID values with multiple spaces or tabs between directive names and values.
  - Applied consistent sanitization to directive values for more reliable configuration and audit output.

- **Tests**
  - Added regression coverage confirming component signatures in JSON audit logs, including tab-separated configuration.
  - Added coverage verifying web application IDs configured with tab-separated values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->