### PR TITLE
fix(windows): pin Conan's CMake generator to match the project's

### DIFF
--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -20,7 +20,16 @@ if "%3"=="USE_ASAN" (
 )
 
 cd build\win32
-conan install . -s compiler.cppstd=17 %CI_ASAN% --output-folder=build --build=missing --settings=build_type=%build_type% --settings=arch=%arch%
+@rem Pin Conan's own CMake generator for dependency builds (e.g. yajl, built
+@rem from source on --build=missing) to match the generator used below for
+@rem the main project. Without this, Conan auto-detects a generator from
+@rem whatever Visual Studio version its profile picks up, which on a machine
+@rem with more than one VS install can differ from -G below -- and an older
+@rem dependency's CMakeLists.txt (e.g. yajl's, which still sets deprecated
+@rem policies like CMP0026 to OLD) may not configure under a newer,
+@rem auto-detected generator/CMake even though it configures fine under the
+@rem one this project actually targets.
+conan install . -s compiler.cppstd=17 %CI_ASAN% -c tools.cmake.cmaketoolchain:generator="Visual Studio 17 2022" --output-folder=build --build=missing --settings=build_type=%build_type% --settings=arch=%arch%
 cd build
 cmake --fresh .. -G "Visual Studio 17 2022" -DCMAKE_TOOLCHAIN_FILE=conan_toolchain.cmake -DUSE_ASAN=%ASAN_FLAG% %4 %5 %6 %7 %8 %9
 cmake --build . --config %build_type%

--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -9,6 +9,12 @@ echo Build type: %build_type%
 if not "%2"=="" (set arch=%2) else (set arch=x86_64)
 echo Arch: %arch%
 
+@rem Single source of truth for the targeted Visual Studio version: both the
+@rem Conan-side generator pin below and the CMake -G flag must agree, or
+@rem dependencies built from source (e.g. yajl, on --build=missing) can end
+@rem up configured under a different VS/CMake than the main project.
+set VS_GENERATOR=Visual Studio 17 2022
+
 if "%3"=="USE_ASAN" (
     echo Address Sanitizer: Enabled
     set CI_ASAN=-c tools.build:cxxflags="[""/fsanitize=address""]"
@@ -20,18 +26,11 @@ if "%3"=="USE_ASAN" (
 )
 
 cd build\win32
-@rem Pin Conan's own CMake generator for dependency builds (e.g. yajl, built
-@rem from source on --build=missing) to match the generator used below for
-@rem the main project. Without this, Conan auto-detects a generator from
-@rem whatever Visual Studio version its profile picks up, which on a machine
-@rem with more than one VS install can differ from -G below -- and an older
-@rem dependency's CMakeLists.txt (e.g. yajl's, which still sets deprecated
-@rem policies like CMP0026 to OLD) may not configure under a newer,
-@rem auto-detected generator/CMake even though it configures fine under the
-@rem one this project actually targets.
-conan install . -s compiler.cppstd=17 %CI_ASAN% -c tools.cmake.cmaketoolchain:generator="Visual Studio 17 2022" --output-folder=build --build=missing --settings=build_type=%build_type% --settings=arch=%arch%
+@rem Pin Conan's own generator for dependency builds (e.g. yajl, built from
+@rem source on --build=missing) to VS_GENERATOR too -- see the note above.
+conan install . -s compiler.cppstd=17 %CI_ASAN% -c tools.cmake.cmaketoolchain:generator="%VS_GENERATOR%" --output-folder=build --build=missing --settings=build_type=%build_type% --settings=arch=%arch%
 cd build
-cmake --fresh .. -G "Visual Studio 17 2022" -DCMAKE_TOOLCHAIN_FILE=conan_toolchain.cmake -DUSE_ASAN=%ASAN_FLAG% %4 %5 %6 %7 %8 %9
+cmake --fresh .. -G "%VS_GENERATOR%" -DCMAKE_TOOLCHAIN_FILE=conan_toolchain.cmake -DUSE_ASAN=%ASAN_FLAG% %4 %5 %6 %7 %8 %9
 cmake --build . --config %build_type%
 
 popd


### PR DESCRIPTION
## Summary

Fixes #3604.

`conan install` (in `vcbuild.bat`) let Conan auto-detect its own CMake generator for dependencies built from source (`--build=missing`, e.g. `yajl`), based on whatever Visual Studio version its auto-detected profile picks up. On a machine with more than one VS version installed, that can differ from the `"Visual Studio 17 2022"` generator this script explicitly requests for the main project two lines later via `cmake --fresh .. -G "Visual Studio 17 2022"`.

`yajl/2.1.0`'s own `CMakeLists.txt` still does `cmake_policy(SET CMP0026 OLD)`, a policy newer CMake versions have dropped `OLD`-behavior support for entirely. Under a newer, auto-detected generator/CMake (observed: `"Visual Studio 18 2026"` on a GitHub-hosted `windows-2025` runner that had more than one VS install), `yajl`'s configure step hard-errors on that unsupported policy before it ever gets to build. Under the generator this project actually targets, it configures fine.

- Explicitly pass the same generator to `conan install` via `-c tools.cmake.cmaketoolchain:generator`, so dependency builds use the identical toolchain as the main project rather than whatever a given machine's Conan profile auto-detection happens to prefer.
- Deduped the generator string into a single `VS_GENERATOR` variable referenced by both the Conan and CMake invocations, so a future VS-version bump only needs to change one line instead of two that must be kept in sync.

Reported downstream via `ModSecurity-nginx`'s Windows CI ([owasp-modsecurity/ModSecurity-nginx#388](https://github.com/owasp-modsecurity/ModSecurity-nginx/issues/388) built this via `vcbuild.bat` and hit this exact failure).

## Note on validation

This repo's own PR-triggered Windows CI (`ci.yml`/`ci_new.yml`) runs on `windows-2022`, which — as far as I can tell — only has one Visual Studio version installed, so it's unlikely to reproduce the generator-mismatch this fixes even without the fix. The pin is a no-op when only one matching VS version is present either way, so it shouldn't regress that CI; real confirmation that this resolves the original failure will need a `windows-2025`-class runner (or a maintainer's machine with more than one VS version installed).

## Test plan

- [x] Reviewed the `-c tools.cmake.cmaketoolchain:generator` conf key against Conan's `CMakeToolchain._get_generator()` source to confirm it's the correct override point.
- [x] CI: confirm `ci.yml`/`ci_new.yml` (`windows-2022`) still pass — expected to be a no-op there.
- [ ] Confirm on a `windows-2025`-class runner (or a machine with multiple VS installs) that this resolves the original `CMP0026` failure.