### PR TITLE
ci: statically link MinGW runtime into x86 fuzzy.dll and add 32-bit pool test

### DIFF
--- a/.github/workflows/test-ci-windows.yml
+++ b/.github/workflows/test-ci-windows.yml
@@ -307,25 +307,32 @@ jobs:
     - name: Test IIS Module in 32-bit Application Pool
       shell: pwsh
       run: |
+        $ErrorActionPreference = 'Stop'
         $appcmd = "$env:SystemRoot\system32\inetsrv\appcmd.exe"
 
-        # Create a dedicated 32-bit application pool and site to reproduce the
-        # x86 load issue (error 126) independently of the 64-bit default pool.
+        # The MSI registers the native module "ModSecurity IIS (32bits)" globally,
+        # pointing at %SystemRoot%\SysWOW64\inetsrv\ModSecurityIIS.dll with the
+        # bitness32 precondition. It only loads inside a 32-bit application pool,
+        # which reproduces the x86 load issue (error 126 / missing MinGW runtime).
+        $modules = & $appcmd list modules | Out-String
+        if ($modules -notmatch "ModSecurity IIS \(32bits\)") {
+            Write-Host "::error:: 32-bit ModSecurity module is not registered"
+            exit 1
+        }
+
+        # Create a dedicated 32-bit application pool and site.
         & $appcmd add apppool /name:"ModSec32Test" /enable32BitAppOnWin64:"true" | Out-Null
         & $appcmd add site /name:"ModSec32Test" /id:9999 /physicalPath:"$env:SystemDrive\inetpub\wwwroot" /bindings:"http/*:8081:" | Out-Null
-        & $appcmd set site "ModSec32Test" /[name='ModSec32Test'].application.applicationPool:"ModSec32Test" | Out-Null
-        & $appcmd add module /name:"ModSecurity" /image:"%windir%\SysWOW64\inetsrv\ModSecurityIIS.dll" /appliesTo:"ModSec32Test" | Out-Null
+        & $appcmd set app "ModSec32Test/" /applicationPool:"ModSec32Test" | Out-Null
 
         Restart-Service W3SVC -Force
 
-        try {
-            $response = Invoke-WebRequest "http://localhost:8081/" -UseBasicParsing -SkipHttpErrorCheck -TimeoutSec 30
-            Write-Host "PASS: 32-bit pool returned $($response.StatusCode)"
-        }
-        catch {
-            Write-Host "ERROR: 32-bit pool request failed: $($_.Exception.Message)"
+        $response = Invoke-WebRequest "http://localhost:8081/" -UseBasicParsing -SkipHttpErrorCheck -TimeoutSec 30
+        if ($response.StatusCode -ne 200) {
+            Write-Host "::error:: 32-bit pool returned unexpected status $($response.StatusCode)"
             exit 1
         }
+        Write-Host "PASS: 32-bit pool returned $($response.StatusCode)"
 
         # Any x86 load failure (e.g. missing MinGW runtime DLLs -> error 126)
         # surfaces as an IIS event 2280 / 'dll failed to load' entry.

--- a/.github/workflows/test-ci-windows.yml
+++ b/.github/workflows/test-ci-windows.yml
@@ -61,18 +61,14 @@ jobs:
         cd ssdeep
         autoreconf -i
         
-        if [ "${{ matrix.arch }}" = "x86" ]; then
-          ./configure --enable-shared --disable-static CFLAGS="-O3" CXXFLAGS="-O3" --build=i686-pc-mingw32
-        else
-          ./configure --enable-shared --disable-static CFLAGS="-O3" CXXFLAGS="-O3"
-        fi
-        
+        ./configure --enable-shared --disable-static CFLAGS="-O3 -static-libgcc"
+
         make dll
 
         mkdir -p "${MSYS2_WORKSPACE}/ssdeep-install/"
-        cp -v fuzzy.dll "${MSYS2_WORKSPACE}/ssdeep-install/"
-        cp -v fuzzy.h "${MSYS2_WORKSPACE}/ssdeep-install/"
-        cp -v fuzzy.def "${MSYS2_WORKSPACE}/ssdeep-install/"
+        cp -v fuzzy.dll  "${MSYS2_WORKSPACE}/ssdeep-install/"
+        cp -v fuzzy.h    "${MSYS2_WORKSPACE}/ssdeep-install/"
+        cp -v fuzzy.def  "${MSYS2_WORKSPACE}/ssdeep-install/"
 
     - name: Restore vcpkg cache
       id: vcpkg-cache
@@ -307,6 +303,44 @@ jobs:
         }
 
         Get-EventLog -LogName Application -Source ModSecurity | Format-List
+
+    - name: Test IIS Module in 32-bit Application Pool
+      shell: pwsh
+      run: |
+        $appcmd = "$env:SystemRoot\system32\inetsrv\appcmd.exe"
+
+        # Create a dedicated 32-bit application pool and site to reproduce the
+        # x86 load issue (error 126) independently of the 64-bit default pool.
+        & $appcmd add apppool /name:"ModSec32Test" /enable32BitAppOnWin64:"true" | Out-Null
+        & $appcmd add site /name:"ModSec32Test" /id:9999 /physicalPath:"$env:SystemDrive\inetpub\wwwroot" /bindings:"http/*:8081:" | Out-Null
+        & $appcmd set site "ModSec32Test" /[name='ModSec32Test'].application.applicationPool:"ModSec32Test" | Out-Null
+        & $appcmd add module /name:"ModSecurity" /image:"%windir%\SysWOW64\inetsrv\ModSecurityIIS.dll" /appliesTo:"ModSec32Test" | Out-Null
+
+        Restart-Service W3SVC -Force
+
+        try {
+            $response = Invoke-WebRequest "http://localhost:8081/" -UseBasicParsing -SkipHttpErrorCheck -TimeoutSec 30
+            Write-Host "PASS: 32-bit pool returned $($response.StatusCode)"
+        }
+        catch {
+            Write-Host "ERROR: 32-bit pool request failed: $($_.Exception.Message)"
+            exit 1
+        }
+
+        # Any x86 load failure (e.g. missing MinGW runtime DLLs -> error 126)
+        # surfaces as an IIS event 2280 / 'dll failed to load' entry.
+        $badPattern = 'dll failed to load|The data is the error|ERROR_MOD_NOT_FOUND|failed to load'
+        $badEvents = Get-EventLog -LogName Application -Newest 100 |
+            Where-Object { $_.Message -match $badPattern } |
+            Where-Object { $_.Source -match 'IIS|W3SVC|IIS-W3SVC|IIS-W3WP|ModSecurity' }
+
+        if ($badEvents -and $badEvents.Count -gt 0) {
+            Write-Host '::error:: 32-bit pool reported module load errors'
+            $badEvents | Select-Object TimeGenerated, Source, EntryType, EventID, Message | Format-List
+            exit 1
+        }
+
+        Write-Host "PASS: 32-bit application pool loaded ModSecurity module successfully"
 
     - name: Install go-ftw
       shell: pwsh


### PR DESCRIPTION
## Summary

Fixes #3599

The CI-produced x86 IIS module (`fuzzy.dll`, ssdeep) was built with MinGW gcc and imported the MinGW runtime DLLs (`libgcc_s_dw2-1.dll` -> `libwinpthread-1.dll`). These were not packaged in the MSI, so the x86 module failed to load in 32-bit application pools with error 126 (`ERROR_MOD_NOT_FOUND`), while the x64 module worked fine.

### Fix

In `.github/workflows/test-ci-windows.yml`, build ssdeep with `-static-libgcc` so the MinGW runtime is statically linked into `fuzzy.dll`. The resulting x86 DLL is self-contained and loads cleanly in 32-bit application pools without needing the external MinGW runtime DLLs.

### Regression test

Added a new `Test IIS Module in 32-bit Application Pool` step that:
1. Verifies the globally-registered `ModSecurity IIS (32bits)` native module exists.
2. Creates a dedicated 32-bit application pool and site, then confirms a request returns HTTP 200.
3. Checks the Application event log for `dll failed to load` / error 126 entries.

The test was validated against the previous (broken) build: with the old dynamic-link build the 32-bit pool returned **HTTP 503** (module failed to load) and the step correctly failed; with this fix it returns **HTTP 200** and passes.

## Validation

- Fixed build: all jobs green, including the new 32-bit pool test (HTTP 200, no load errors).
- Old build (temporary revert): the new 32-bit pool test correctly failed with `unexpected status 503`, confirming it reproduces and catches the x86 load issue.
