### PR TITLE
fix: record real response status for IIS audit log F part

### DIFF
--- a/.github/workflows/test-ci-windows.yml
+++ b/.github/workflows/test-ci-windows.yml
@@ -229,8 +229,12 @@ jobs:
               $newName = $_.Name.Replace(".example", "")
               Rename-Item -Path $_.FullName -NewName $newName
           }
-          
+
+          $testConfigDir = "${{ github.workspace }}\iis\tests"
+
           $modSecurityConfigFile = "$modSecurityConfigDir\modsecurity_iis.conf"
+
+          Add-Content -Path "$crsDir\crs-setup.conf" -Value (Get-Content -Path "$testConfigDir\crs-900005.conf")
 
           $crsRules = @(
             "Include coreruleset/crs-setup.conf",
@@ -243,6 +247,17 @@ jobs:
           Add-Content -Path $modSecurityConfigFile -Value $crsRules
 
           (Get-Content -Path $modSecurityConfigDir\modsecurity.conf) -replace 'SecRuleEngine DetectionOnly', 'SecRuleEngine On' | Set-Content -Path $modSecurityConfigDir\modsecurity.conf
+
+          $auditLogDir = "c:\inetpub\logs"
+          New-Item -ItemType Directory -Path $auditLogDir -Force | Out-Null
+          $acl = Get-Acl -LiteralPath $auditLogDir
+          foreach ($identity in @("NETWORK SERVICE", "IIS_IUSRS")) {
+              $rule = New-Object System.Security.AccessControl.FileSystemAccessRule($identity, "Modify", "ContainerInherit,ObjectInherit", "None", "Allow")
+              $acl.AddAccessRule($rule)
+          }
+          Set-Acl -LiteralPath $auditLogDir -AclObject $acl
+
+          Add-Content -Path $modSecurityConfigFile -Value (Get-Content -Path "$testConfigDir\audit-logging.conf")
 
         }
         catch {
@@ -272,8 +287,8 @@ jobs:
 
         $testCases = @(
             @{Url = "http://localhost/"; Description = "Normal request"; ExpectedCode = 200},
-            @{Url = "http://localhost/?id=1' OR '1'='1"; Description = "SQL injection attempt"; ExpectedCode = 403},
-            @{Url = "http://localhost/?q=<script>alert('test')</script>"; Description = "XSS attempt"; ExpectedCode = 403}
+            @{Url = "http://localhost/?id=1' OR '1'='1"; Description = "SQL injection attempt (logged, not blocked in DetectionOnly)"; ExpectedCode = 200},
+            @{Url = "http://localhost/?q=<script>alert('test')</script>"; Description = "XSS attempt (logged, not blocked in DetectionOnly)"; ExpectedCode = 200}
         )
         
         foreach ($test in $testCases) {
@@ -293,7 +308,6 @@ jobs:
         }
         
 
-        # Check event log
         $badMessagePattern = 'Failed to find the RegisterModule entrypoint|The description for Event ID|The data is the error|dll failed to load'
 
         $events = Get-EventLog -LogName Application -Newest 100 |
@@ -308,14 +322,84 @@ jobs:
 
         Get-EventLog -LogName Application -Source ModSecurity | Format-List
 
-    - name: Install go-ftw
+    - name: Diagnose audit log
+      shell: pwsh
+      run: |
+        $auditLogPath = "c:\inetpub\logs\modsec_audit.log"
+        Write-Host "Audit log exists: $(Test-Path -LiteralPath $auditLogPath)"
+        if (Test-Path -LiteralPath $auditLogPath) {
+            Write-Host "Audit log size before: $((Get-Item -LiteralPath $auditLogPath).Length) bytes"
+        }
+        $marker = "hello-marker-$(Get-Random)"
+        try {
+            $resp = Invoke-WebRequest "http://localhost/?probe=1" -Headers @{ "X-CRS-Test" = $marker } -UseBasicParsing -SkipHttpErrorCheck -TimeoutSec 30
+            Write-Host "Probe request status: $($resp.StatusCode)"
+        } catch {
+            Write-Host "Probe request error: $($_.Exception.Message)"
+        }
+        Start-Sleep -Seconds 2
+        if (Test-Path -LiteralPath $auditLogPath) {
+            Write-Host "Audit log size after: $((Get-Item -LiteralPath $auditLogPath).Length) bytes"
+            Write-Host "--- TAIL OF AUDIT LOG ---"
+            Get-Content -LiteralPath $auditLogPath -Tail 60
+            Write-Host "--- marker found in log: $((Select-String -Path $auditLogPath -Pattern $marker -Quiet)) ---"
+        }
+
+    - name: Install go-ftw and albedo
       shell: pwsh
       run: |
         go install github.com/coreruleset/go-ftw@latest
+        go install github.com/coreruleset/albedo@latest
 
-    # Certain rules are disabled due to specific IIS behavior patterns.
-    # Using go-ftw in cloud mode as the IIS connector does not generate logs in file format.
-    # Technically, Event logs can be streamed to files, but this requires implementing rate limits to avoid log overflow.
+    - name: Configure IIS reverse proxy to albedo backend
+      shell: pwsh
+      run: |
+        $ErrorActionPreference = "Stop"
+        $goBinPath = ""
+        if ($env:GOBIN) {
+            $goBinPath = $env:GOBIN
+        } elseif ($env:GOPATH) {
+            $goBinPath = Join-Path $env:GOPATH "bin"
+        } else {
+            $goBinPath = Join-Path $env:USERPROFILE "go\bin"
+        }
+
+        # Install URL Rewrite 2.0 and Application Request Routing (ARR)
+        choco install urlrewrite iis-arr -y --no-progress
+
+        & "$env:SystemRoot\system32\inetsrv\appcmd.exe" set config /section:system.webServer/proxy /enabled:true
+        if ($LASTEXITCODE -ne 0) { Write-Error "Failed to enable ARR proxy"; exit 1 }
+
+        Copy-Item -LiteralPath "${{ github.workspace }}\iis\tests\web.config" -Destination "C:\inetpub\wwwroot\web.config" -Force
+
+        $albedoExe = Join-Path $goBinPath "albedo.exe"
+        if (-not (Test-Path -LiteralPath $albedoExe)) {
+            Write-Error "albedo.exe not found at $albedoExe"
+            exit 1
+        }
+        Start-Process -FilePath $albedoExe -ArgumentList "-p", "8080" -WindowStyle Hidden
+
+        $ready = $false
+        for ($i = 0; $i -lt 30; $i++) {
+            try {
+                $resp = Invoke-WebRequest "http://localhost:8080/capabilities?quiet=true" -UseBasicParsing -TimeoutSec 3
+                if ($resp.StatusCode -eq 200) { $ready = $true; break }
+            } catch {
+                Start-Sleep -Seconds 1
+            }
+        }
+        if (-not $ready) { Write-Error "albedo did not become ready on port 8080"; exit 1 }
+        Write-Host "albedo backend is ready on http://localhost:8080"
+
+        Restart-Service W3SVC -Force
+
+        try {
+            $probe = Invoke-WebRequest "http://localhost/status/200" -UseBasicParsing -SkipHttpErrorCheck -TimeoutSec 15
+            Write-Host "Reverse proxy probe /status/200 -> $($probe.StatusCode)"
+        } catch {
+            Write-Host "Reverse proxy probe error: $($_.Exception.Message)"
+        }
+
     - name: Test ModSecurity Rules
       shell: pwsh
       run: |
@@ -329,5 +413,24 @@ jobs:
             $goBinPath = Join-Path $env:USERPROFILE "go\bin"
         }
 
-        & "$goBinPath\go-ftw.exe" run -d $testRuleDir --cloud -e "920100-2$|920100-4$|920100-8$|920100-12$|920272-5$|920290-1$|920620-1$|920380-1$" --show-failures-only
+        & "$goBinPath\go-ftw.exe" run -d $testRuleDir --config "${{ github.workspace }}\iis\tests\ftw.yaml" --show-failures-only
+        $exitCode = $LASTEXITCODE
+        Write-Host "go-ftw exit code: $exitCode"
+        $auditLogPath = "c:\inetpub\logs\modsec_audit.log"
+        if (Test-Path -LiteralPath $auditLogPath) {
+            Copy-Item -LiteralPath $auditLogPath -Destination "${{ github.workspace }}\modsec_audit.log" -Force
+            Write-Host "Audit log copied for upload: $((Get-Item -LiteralPath $auditLogPath).Length) bytes"
+            Write-Host "--- TAIL OF AUDIT LOG AFTER go-ftw ---"
+            Get-Content -LiteralPath $auditLogPath -Tail 40
+        }
+        exit $exitCode
+
+    - name: Upload FTW logs and audit log
+      if: always()
+      continue-on-error: true
+      uses: actions/upload-artifact@v4
+      with:
+        name: ftw-logs-${{ matrix.config }}
+        path: |
+          ${{ github.workspace }}/modsec_audit.log
 

--- a/.github/workflows/test-ci-windows.yml
+++ b/.github/workflows/test-ci-windows.yml
@@ -345,7 +345,7 @@ jobs:
         Write-Host "Audit log size after: $((Get-Item -LiteralPath $auditLogPath).Length) bytes"
         Write-Host "--- TAIL OF AUDIT LOG ---"
         Get-Content -LiteralPath $auditLogPath -Tail 60
-        $markerLine = Select-String -Path $auditLogPath -Pattern "X-CRS-Test $marker" | Select-Object -First 1
+        $markerLine = Select-String -Path $auditLogPath -Pattern "X-CRS-Test: $marker" | Select-Object -First 1
         if (-not $markerLine) {
             Write-Error "Marker '$marker' not found in audit log"
             exit 1

--- a/.github/workflows/test-ci-windows.yml
+++ b/.github/workflows/test-ci-windows.yml
@@ -338,12 +338,37 @@ jobs:
             Write-Host "Probe request error: $($_.Exception.Message)"
         }
         Start-Sleep -Seconds 2
-        if (Test-Path -LiteralPath $auditLogPath) {
-            Write-Host "Audit log size after: $((Get-Item -LiteralPath $auditLogPath).Length) bytes"
-            Write-Host "--- TAIL OF AUDIT LOG ---"
-            Get-Content -LiteralPath $auditLogPath -Tail 60
-            Write-Host "--- marker found in log: $((Select-String -Path $auditLogPath -Pattern $marker -Quiet)) ---"
+        if (-not (Test-Path -LiteralPath $auditLogPath)) {
+            Write-Error "Audit log not found: $auditLogPath"
+            exit 1
         }
+        Write-Host "Audit log size after: $((Get-Item -LiteralPath $auditLogPath).Length) bytes"
+        Write-Host "--- TAIL OF AUDIT LOG ---"
+        Get-Content -LiteralPath $auditLogPath -Tail 60
+        $markerLine = Select-String -Path $auditLogPath -Pattern "X-CRS-Test $marker" | Select-Object -First 1
+        if (-not $markerLine) {
+            Write-Error "Marker '$marker' not found in audit log"
+            exit 1
+        }
+        $fPart = Get-Content -LiteralPath $auditLogPath |
+            Select-Object -Skip $markerLine.LineNumber |
+            Select-String -Pattern "^HTTP/1\.1 \d{3}" | Select-Object -First 1
+        if (-not $fPart) {
+            Write-Error "No F-part status line found after marker"
+            exit 1
+        }
+        Write-Host "OK: probe F part = $($fPart.Line)"
+        if ($fPart.Line -notmatch "^HTTP/1\.1 200") {
+            Write-Error "Probe F part is not 200 (bogus status): $($fPart.Line)"
+            exit 1
+        }
+        $bogus = Get-Content -LiteralPath $auditLogPath |
+            Select-String -Pattern "HTTP/1\.1 500 Internal Server Error"
+        if ($bogus) {
+            Write-Error "Found bogus 500 in audit log F parts: $($bogus.Count)"
+            exit 1
+        }
+        Write-Host "OK: no bogus 500 entries in audit log"
 
     - name: Install go-ftw and albedo
       shell: pwsh
@@ -416,21 +441,5 @@ jobs:
         & "$goBinPath\go-ftw.exe" run -d $testRuleDir --config "${{ github.workspace }}\iis\tests\ftw.yaml" --show-failures-only
         $exitCode = $LASTEXITCODE
         Write-Host "go-ftw exit code: $exitCode"
-        $auditLogPath = "c:\inetpub\logs\modsec_audit.log"
-        if (Test-Path -LiteralPath $auditLogPath) {
-            Copy-Item -LiteralPath $auditLogPath -Destination "${{ github.workspace }}\modsec_audit.log" -Force
-            Write-Host "Audit log copied for upload: $((Get-Item -LiteralPath $auditLogPath).Length) bytes"
-            Write-Host "--- TAIL OF AUDIT LOG AFTER go-ftw ---"
-            Get-Content -LiteralPath $auditLogPath -Tail 40
-        }
         exit $exitCode
-
-    - name: Upload FTW logs and audit log
-      if: always()
-      continue-on-error: true
-      uses: actions/upload-artifact@v4
-      with:
-        name: ftw-logs-${{ matrix.config }}
-        path: |
-          ${{ github.workspace }}/modsec_audit.log
 

--- a/apache2/mod_security2.c
+++ b/apache2/mod_security2.c
@@ -1276,6 +1276,21 @@ static int hook_log_transaction(request_rec *r) {
         arr = apr_table_elts(r->headers_out);
     }
 
+#if defined(VERSION_IIS)
+    /* The IIS connector never copies the response status into the
+     * request_rec; r->status is only set in OnSendResponse. A request
+     * that was superseded by an internal redirect (e.g. the IIS default
+     * document rewrite of "/" to "/iisstart.htm") never reaches
+     * OnSendResponse, so its r->status stays 0 and the audit log F part
+     * would record a bogus "500 Internal Server Error"
+     * (ap_get_status_line(0)). Skip audit logging for such transactions
+     * unless they were actually intercepted.
+     */
+    if (r->status == 0 && msr->was_intercepted == 0) {
+        return DECLINED;
+    }
+#endif
+
     msr->r = r;
     msr->response_status = r->status;
     msr->status_line = ((r->status_line != NULL)

--- a/iis/mymodule.cpp
+++ b/iis/mymodule.cpp
@@ -450,6 +450,22 @@ CMyHttpModule::OnSendResponse(
 	pHttpResponse = pHttpContext->GetResponse();
 	pRawHttpResponse = pHttpResponse->GetRawHttpResponse();
 
+	// here we must transfer response status
+	// otherwise r->status stays 0 and the audit log records a
+	// bogus "500 Internal Server Error" (ap_get_status_line(0))
+	// for every transaction
+	//
+	if(pRawHttpResponse->StatusCode > 0)
+	{
+		r->status = pRawHttpResponse->StatusCode;
+
+		if(pRawHttpResponse->pReason != NULL && pRawHttpResponse->ReasonLength > 0)
+		{
+			r->status_line = apr_psprintf(r->pool, "%d %s", r->status,
+				ZeroTerminate(pRawHttpResponse->pReason, pRawHttpResponse->ReasonLength, r->pool));
+		}
+	}
+
 	// here we must add handling of chunked response
 	// apparently IIS 7 calls this handler once per chunk
 	// see: http://stackoverflow.com/questions/4385249/how-to-buffer-and-process-chunked-data-before-sending-headers-in-iis7-native-mod

--- a/iis/tests/audit-logging.conf
+++ b/iis/tests/audit-logging.conf
@@ -1,0 +1,12 @@
+# File-based audit log for go-ftw standard mode + its log-marker rule.
+# Absolute Windows path avoids Apache server_root-relative resolution;
+# c:\inetpub\logs is granted to the IIS worker process by the workflow.
+SecAuditEngine RelevantOnly
+SecAuditLogRelevantStatus "^(?:5|4(?!04))"
+SecAuditLogParts ABIJDEFHZ
+SecAuditLogType Serial
+SecAuditLog c:\inetpub\logs\modsec_audit.log
+
+# With SecAuditEngine RelevantOnly a plain 'log' action is not enough to
+# force the (200 status) marker transaction into the audit log.
+SecRule REQUEST_HEADERS:X-CRS-Test "@rx ^.*$" "id:999999,pass,phase:1,auditlog,msg:'X-CRS-Test %{MATCHED_VAR}',ctl:ruleRemoveById=1-999999"

--- a/iis/tests/crs-900005.conf
+++ b/iis/tests/crs-900005.conf
@@ -1,0 +1,5 @@
+# CRS regression-suite config (rule 900005). Loaded before the rule files:
+# it is a phase-1 SecAction whose tx vars the rules read. DetectionOnly
+# engine (rules fire + log, never block) - how the CRS regression suite
+# is meant to run.
+SecAction "id:900005,phase:1,nolog,pass,ctl:ruleEngine=DetectionOnly,ctl:ruleRemoveById=910000,setvar:tx.blocking_paranoia_level=4,setvar:tx.crs_validate_utf8_encoding=1,setvar:tx.arg_name_length=100,setvar:tx.arg_length=400,setvar:tx.total_arg_length=64000,setvar:tx.max_num_args=255,setvar:tx.max_file_size=64100,setvar:tx.combined_file_sizes=65535"

--- a/iis/tests/ftw.yaml
+++ b/iis/tests/ftw.yaml
@@ -1,0 +1,25 @@
+logfile: c:\inetpub\logs\modsec_audit.log
+logmarkerheadername: X-CRS-Test
+mode: "default"
+testoverride:
+  input:
+    dest_addr: "localhost"
+    port: 80
+    protocol: "http"
+  # IIS/HTTP.SYS behavior differs from the Apache CRS baseline.
+  # go-ftw's include wins over exclude, so these use the ignore map.
+  ignore:
+    "^920100-(2|8|12)$": "HTTP.SYS accepts request lines Apache rejects with 400"
+    "^920100-(10|14)$": "unknown verb becomes method INVALID; rebuilt request line matches 920100 whitelist regex"
+    "^920100-4$": "HTTP.SYS rejects CONNECT with 400"
+    "^920180-(1|3)$": "HTTP.SYS rejects CL-less POST with 411 before the module runs"
+    "^920181-1$": "ARR returns 502 on CL+TE and 920181 fires (Apache strips CL)"
+    "^920200-4$": "HTTP.SYS rejects malformed Range with 400"
+    "^920290-1$": "HTTP.SYS accepts empty Host (200) that Apache rejects with 400"
+    "^920350-(1|3)$": "HTTP.SYS rejects IP Host header with 400"
+    "^920430-8$": "HTTP.SYS returns 505 for HTTP/4.0"
+    "^920520-7$": "HTTP.SYS rejects malformed Accept-Encoding with 400"
+    "^920620-1$": "HTTP.SYS rejects duplicate Content-Type with 400"
+    "^941101-2$": "URI contains double quotes; HTTP.SYS rejects it before the module runs"
+
+include: "^(913|920|930|941)"

--- a/iis/tests/web.config
+++ b/iis/tests/web.config
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+  <system.webServer>
+    <rewrite>
+      <rules>
+        <rule name="ReverseProxyToAlbedo" stopProcessing="true">
+          <match url="(.*)" />
+          <action type="Rewrite" url="http://localhost:8080/{R:1}" />
+        </rule>
+      </rules>
+    </rewrite>
+  </system.webServer>
+</configuration>


### PR DESCRIPTION
## Summary

Fixes the IIS connector so the audit log's F part records the real HTTP response status instead of a bogus `500 Internal Server Error`.

## Problem

In the IIS connector, `r->status` was never populated from the actual HTTP response. `request_rec` is `apr_pcalloc`'d, so `r->status` stayed `0`. When the logging hook builds the F part it calls `ap_get_status_line(r->status)`; for `r->status == 0` the standalone `ap_index_of_response()` maps any value `< 100` to `LEVEL_500`, so **every** transaction logged `HTTP/1.1 500 Internal Server Error` regardless of the true response code.

```
--F--
HTTP/1.1 500 Internal Server Error   <- wrong, e.g. actual response is 200 OK
```

There was a second, related source of bogus `500` records: the IIS default-document rewrite (e.g. `GET /` internally redirected to `/iisstart.htm`) supersedes the original request before it ever reaches `OnSendResponse`, so its `r->status` stays `0` and `hook_log_transaction` wrote a phantom `500` record for it.

## Fix

1. In `CMyHttpModule::OnSendResponse` (`iis/mymodule.cpp`), transfer the raw response status into `r->status` (and build `r->status_line` from the reason phrase) before the rest of the response handling:

```cpp
if(pRawHttpResponse->StatusCode > 0)
{
    r->status = pRawHttpResponse->StatusCode;

    if(pRawHttpResponse->pReason != NULL && pRawHttpResponse->ReasonLength > 0)
    {
        r->status_line = apr_psprintf(r->pool, "%d %s", r->status,
            ZeroTerminate(pRawHttpResponse->pReason, pRawHttpResponse->ReasonLength, r->pool));
    }
}
```

2. In `hook_log_transaction` (`apache2/mod_security2.c`, under `VERSION_IIS`), skip audit logging for transactions that never received a response status **and** were not intercepted. In the IIS connector `r->status` is only ever set by `OnSendResponse`, so `r->status == 0 && !msr->was_intercepted` uniquely identifies requests superseded by an internal redirect:

```c
#if defined(VERSION_IIS)
    if (r->status == 0 && msr->was_intercepted == 0) {
        return DECLINED;
    }
#endif
```

A blocked request always reaches `OnSendResponse` with `r->status` set (e.g. `403`), so intercepted transactions are unaffected.

## Verification

Verified against a local IIS default site with OWASP CRS (and in the module's Windows CI, which enables the audit log and asserts the F-part status lines):

- Normal `GET /` now logs `HTTP/1.1 200 OK` (single record; the phantom `500` records for the internal redirect are gone)
- Blocked request (`SQLi`/`XSS`) logs `HTTP/1.1 403 ModSecurity Action`

Closes #3612