### PR TITLE
Fix case-insensitive request header target exclusions

### DIFF
--- a/src/variables/variable.h
+++ b/src/variables/variable.h
@@ -665,7 +665,7 @@ class Variables : public std::vector<Variable *> {
                 if (r) {
                     return r->m_r.searchAll(v->getKey()).size() > 0;
                 }
-                return v->getKeyWithCollection() == *m->m_fullName.get();
+                return utils::string::toupper(v->getKeyWithCollection()) == utils::string::toupper(*m->m_fullName.get());
             }) != end();
     };
 };

--- a/test/test-cases/regression/config-update-target-by-id.json
+++ b/test/test-cases/regression/config-update-target-by-id.json
@@ -224,4 +224,47 @@
       "SecRule ARGS_NAMES \"@contains yyy\" \"id:1,phase:2,deny,status:403\""
     ]
   }
+
+  ,
+  {
+    "enabled": 1,
+    "version_min": 300000,
+    "title": "SecRuleUpdateTargetById - REQUEST_HEADERS exclusion is case insensitive",
+    "client": {
+      "ip": "200.249.12.31",
+      "port": 123
+    },
+    "server": {
+      "ip": "200.249.12.31",
+      "port": 80
+    },
+    "request": {
+      "headers": {
+        "Host": "localhost",
+        "Referer": "This is an attack"
+      },
+      "uri": "/index.html",
+      "method": "GET",
+      "body": [
+        ""
+      ]
+    },
+    "response": {
+      "headers": {
+        "Content-Length": "0"
+      },
+      "body": [
+        ""
+      ]
+    },
+    "expected": {
+      "http_code": 200
+    },
+    "rules": [
+      "SecRuleEngine On",
+      "SecRuleUpdateTargetById 1 !REQUEST_HEADERS:referer",
+      "SecRule REQUEST_HEADERS:Referer \"@contains attack\" \"id:1,phase:1,deny,status:403\""
+    ]
+  }
+
 ]


### PR DESCRIPTION
## Summary

Fix case-sensitive matching of REQUEST_HEADERS target exclusions.

Previously, an exclusion such as:

SecRuleUpdateTargetById 1 !REQUEST_HEADERS:referer

could fail to exclude the corresponding request header when the header name
used a different case.

This change makes REQUEST_HEADERS target exclusion matching case-insensitive.

## Testing

Added a regression test covering case-insensitive REQUEST_HEADERS exclusion.

- 6 regression tests run
- 6 passed
- 0 failed