### PR TITLE
iis: fail closed (HTTP 500) on ModSecurity config load failure

### DIFF
--- a/iis/moduleconfig.h
+++ b/iis/moduleconfig.h
@@ -69,6 +69,9 @@ class MODSECURITY_STORED_CONTEXT : public IHttpStoredContext
 
 	void*			  m_Config;
 
+	time_t configFailTime = 0;
+	bool configLoadingFailed = false;
+
 private:
     HRESULT 
     GetBooleanPropertyValue( 

--- a/iis/mymodule.cpp
+++ b/iis/mymodule.cpp
@@ -17,6 +17,8 @@
 #undef inline
 #define inline inline
 
+#include <time.h>
+
 #include "winsock2.h"
 
 //  IIS7 Server API header file
@@ -726,6 +728,7 @@ CMyHttpModule::OnBeginRequest(
     
     UNREFERENCED_PARAMETER ( pProvider );
 
+	time_t curr_time = time(NULL);
 	EnterCriticalSection(&m_csLock);
 
     if ( pHttpContext == NULL ) 
@@ -746,9 +749,9 @@ CMyHttpModule::OnBeginRequest(
     
     if ( FAILED( hr ) )
     {
-        //hr = E_UNEXPECTED;
-		hr = S_OK;
-        goto Finished;
+        pHttpContext->GetResponse()->SetStatus(500, "WAF internal error. Unable to get config.");
+        pHttpContext->SetRequestHandled();
+        return RQ_NOTIFICATION_FINISH_REQUEST;
     }
 
 	// If module is disabled, dont go any further
@@ -757,6 +760,26 @@ CMyHttpModule::OnBeginRequest(
 	{
         goto Finished;
 	}
+
+    auto reportConfigurationError = [pConfig, pHttpContext, this] {
+        pConfig->configLoadingFailed = true;
+        pHttpContext->GetResponse()->SetStatus(500, "WAF internal error. Invalid configuration.");
+        pHttpContext->SetRequestHandled();
+        LeaveCriticalSection(&m_csLock);
+        return RQ_NOTIFICATION_FINISH_REQUEST;
+    };
+
+    // If we previously failed to load the config, try again if 10sec passed
+    if (pConfig->configLoadingFailed)
+    {
+		if (difftime(curr_time, pConfig->configFailTime) < 10) {
+			return reportConfigurationError();
+		}
+		else {
+			WriteEventViewerLog("Recycling w3wp worker due to config load fail", EVENTLOG_ERROR_TYPE);
+			g_pHttpServer->RecycleProcess(L"ModSecurity config load failed");
+		}
+    }
 
 	if(pConfig->m_Config == NULL)
 	{
@@ -767,8 +790,8 @@ CMyHttpModule::OnBeginRequest(
 
 		if ( FAILED( hr ) )
 		{
-			hr = E_UNEXPECTED;
-			goto Finished;
+			pConfig->configFailTime = curr_time;
+            return reportConfigurationError();
 		}
 
 		pConfig->m_Config = modsecGetDefaultConfig();
@@ -782,8 +805,8 @@ CMyHttpModule::OnBeginRequest(
 		if ( FAILED( hr ) )
 		{
 			delete path;
-			hr = E_UNEXPECTED;
-			goto Finished;
+			pConfig->configFailTime = curr_time;
+            return reportConfigurationError();
 		}
 
 		if(path[0] != 0)
@@ -793,9 +816,10 @@ CMyHttpModule::OnBeginRequest(
 			if(err != NULL)
 			{
 				WriteEventViewerLog(err, EVENTLOG_ERROR_TYPE);
+				pConfig->configFailTime = curr_time;
 				delete apppath;
 				delete path;
-				goto Finished;
+                return reportConfigurationError();
 			}
 
 			modsecReportRemoteLoadedRules();


### PR DESCRIPTION
## Summary

In `iis/mymodule.cpp`, `CMyHttpModule::OnBeginRequest` currently handles a failure to retrieve or parse the ModSecurity configuration by setting `hr = S_OK` and falling through to `RQ_NOTIFICATION_CONTINUE`. That means a request for which the WAF configuration could not be loaded is passed through **without any inspection** -- i.e. the WAF silently fails open.

On a malformed or missing `modsecurity.conf` (or a config that fails to parse), this leaves the site completely unprotected, with no signal to the client.

## Change

- When the config cannot be retrieved or parsed, return **HTTP 500** (`WAF internal error. ...`) and `SetRequestHandled()` instead of continuing.
- Track `configFailTime` / `configLoadingFailed` on the stored context so a transient failure does not spam the event log every request: within a 10s window the cached failure is reported immediately; after that the w3wp worker is recycled so it re-reads the config.
- Added `#include <time.h>` (the file now uses `time()` / `difftime()`).

## Why fail closed

For a security control, failing open on a bad config is the more dangerous default. Returning 500 makes the failure visible and avoids silently unprotected traffic. (If a deployment truly needs fail-open behaviour this can be discussed, but the safe default is fail closed.)

## Provenance

Adapted from `microsoft/ModSecurity` branch `waf_iis` (config-load-failure handling). Verified still missing on current `v2/master` tip (0875b19, v2.9.14).
