### PR TITLE
iis: drop chunked Transfer-Encoding when Content-Length is set

### DIFF
--- a/iis/mymodule.cpp
+++ b/iis/mymodule.cpp
@@ -1147,6 +1147,17 @@ apr_status_t WriteBodyCallback(request_rec *r, char *buf, unsigned int length)
 		// not possible
     }
 
+	// Remove the Transfer-Encoding header if "chunked" is set in the request.
+	// ModSecurity always sends Content-Length, so leaving chunked would produce a
+	// request with both headers, which is malformed.
+	USHORT teLen = 0;
+	PCSTR te = pHttpRequest->GetHeader(HttpHeaderTransferEncoding, &teLen);
+	if (te != NULL && teLen != 0 &&
+	    0 == stricmp(ZeroTerminate(te, teLen, r->pool), "chunked"))
+	{
+		pHttpRequest->DeleteHeader(HttpHeaderTransferEncoding);
+	}
+
     hr = pHttpRequest->SetHeader(
             HttpHeaderContentLength, 
             szLength, 


### PR DESCRIPTION
## Summary

In `iis/mymodule.cpp`, `WriteBodyCallback` copies the inbound request headers verbatim (including `Transfer-Encoding`) and then sets `Content-Length` on the request. The result can be a request that carries **both** `Transfer-Encoding: chunked` and `Content-Length`, which is malformed and is rejected by some backends / causes ambiguous framing.

## Change

Right before setting `Content-Length`, if the request's `Transfer-Encoding` header is `chunked`, delete it via `pHttpRequest->DeleteHeader(...)`. Only one framing header is left on the forwarded request.

## Provenance

Adapted from `microsoft/ModSecurity` branch `waf_iis`. Verified still missing on current `v2/master` tip (0875b19, v2.9.14).
