### PR TITLE
IIS: fix Content-Length formatting (correct printf specifier + full buffer size)

### DIFF
--- a/iis/mymodule.cpp
+++ b/iis/mymodule.cpp
@@ -639,9 +639,9 @@ CMyHttpModule::OnSendResponse(
 
          ZeroMemory(szLength, sizeof(szLength));
 
-         hr = StringCchPrintfA(
+          hr = StringCchPrintfA(
                     szLength, 
-                    sizeof(szLength) / sizeof(CHAR) - 1, "%d", 
+                    sizeof(szLength) / sizeof(CHAR), "%llu", 
                     ulTotalLength);
 
         if(FAILED(hr))
@@ -1139,7 +1139,7 @@ apr_status_t WriteBodyCallback(request_rec *r, char *buf, unsigned int length)
 
     HRESULT hr = StringCchPrintfA(
             szLength, 
-            sizeof(szLength) / sizeof(CHAR) - 1, "%d", 
+            sizeof(szLength) / sizeof(CHAR), "%u", 
             length);
 
     if(FAILED(hr))
@@ -1227,7 +1227,7 @@ apr_status_t WriteResponseCallback(request_rec *r, char *buf, unsigned int lengt
 
     HRESULT hr = StringCchPrintfA(
             szLength, 
-            sizeof(szLength) / sizeof(CHAR) - 1, "%d", 
+            sizeof(szLength) / sizeof(CHAR), "%u", 
             length);
 
     if(FAILED(hr))


### PR DESCRIPTION
## Summary
Fixes the `Content-Length` header value being corrupted/truncated in the IIS module when ModSecurity has to synthesize it (only-response, non-chunked case).

Two defects were fixed in `iis/mymodule.cpp`:
- `ulTotalLength` is a `ULONGLONG`, but was printed with `"%d"` (32-bit `int`). `printf` only consumed the low 32 bits, producing a wrong header for response bodies larger than ~2 GiB. Now uses `"%llu"`.
- The two other call sites format an `unsigned int` `length` with `"%d"`; changed to `"%u"`.
- `StringCchPrintfA`'s `cchDest` was passed as `sizeof(szLength)/sizeof(CHAR) - 1` (20), which can only hold 19 digits + null and would truncate a 20-digit 64-bit value. Now passes the full buffer size (21, which includes the null terminator).

## Fixes
Closes #3619

## Changed locations
- `iis/mymodule.cpp:644` — `ulTotalLength` (ULONGLONG) -> `"%llu"`
- `iis/mymodule.cpp:1142` — `length` (unsigned int) -> `"%u"`
- `iis/mymodule.cpp:1230` — `length` (unsigned int) -> `"%u"`

All three now pass `sizeof(szLength) / sizeof(CHAR)` as the destination size.
