### PR TITLE
IIS: fix dead Host header fallback (r->hostname == NULL can never be true)

### DIFF
--- a/iis/mymodule.cpp
+++ b/iis/mymodule.cpp
@@ -840,7 +840,7 @@ CMyHttpModule::OnBeginRequest(
 	r->hostname = ConvertUTF16ToUTF8(req->CookedUrl.pHost, req->CookedUrl.HostLength / sizeof(WCHAR), r->pool);
 	r->path_info = ConvertUTF16ToUTF8(req->CookedUrl.pAbsPath, req->CookedUrl.AbsPathLength / sizeof(WCHAR), r->pool);
 
-	if(r->hostname == NULL)
+	if(r->hostname == NULL || r->hostname[0] == '\0')
 	{
 		if(req->Headers.KnownHeaders[HttpHeaderHost].pRawValue != NULL)
 			r->hostname = ZeroTerminate(req->Headers.KnownHeaders[HttpHeaderHost].pRawValue,


### PR DESCRIPTION
## Summary
Fixes the `Host` header fallback being dead code in the IIS module.

`r->hostname` is set from `ConvertUTF16ToUTF8(req->CookedUrl.pHost, ...)` (line 840). That helper **never returns `NULL`** — on NULL/empty input, zero converted bytes, or conversion failure it returns the literal `""` (`mymodule.cpp:180-184`, `:199-202`, `:226-229`); on success it returns a pool-allocated buffer. So `r->hostname` is always non-NULL, and `if(r->hostname == NULL)` at line 843 was never true, silently skipping the `Host` header fallback.

Now the check also triggers on an empty string, so when the request URI carries no host (ordinary HTTP/1.1 `GET /path` + `Host:` header) the host is taken from the `Host` header as intended.

## Fixes
Closes #3621

## Changed location
- `iis/mymodule.cpp:843` — `if(r->hostname == NULL)` → `if(r->hostname == NULL || r->hostname[0] == '\0')`

The helper's contract is intentionally left unchanged so the other callers (`path_info`, `args`) are unaffected.
