### PR TITLE
IIS: fix ReadFileChunk latent overflow (allocate m_dwPageSize, not 1)

### DIFF
--- a/iis/mymodule.cpp
+++ b/iis/mymodule.cpp
@@ -302,7 +302,7 @@ HRESULT CMyHttpModule::ReadFileChunk(HTTP_DATA_CHUNK *chunk, char *buf)
 	HRESULT hr = S_OK;
 
     pIoBuffer = (BYTE *)VirtualAlloc(NULL,
-                                        1,
+                                        m_dwPageSize,
                                         MEM_COMMIT | MEM_RESERVE,
                                         PAGE_READWRITE);
     if (pIoBuffer == NULL)


### PR DESCRIPTION
## Summary
Fixes a latent buffer overflow in `ReadFileChunk` (IIS module).

The I/O scratch buffer was allocated with `VirtualAlloc(NULL, 1, MEM_COMMIT | MEM_RESERVE, PAGE_READWRITE)`, yet `ReadFile` writes `m_dwPageSize` bytes into it (`iis/mymodule.cpp:304`, `:339`). It only worked by accident: `VirtualAlloc` rounds the allocation size up to a full page, and the returned address is page-aligned — so requesting 1 byte commits exactly one page, which happens to equal `m_dwPageSize`. If `m_dwPageSize` ever differed from the system page size, `ReadFile` would write past the committed region (access violation).

## Fixes
Closes #3623

## Changed location
- `iis/mymodule.cpp:305` — allocate the real size: `VirtualAlloc(NULL, m_dwPageSize, MEM_COMMIT | MEM_RESERVE, PAGE_READWRITE)`

The page-aligned address still satisfies the file I/O alignment requirements already used in the function, and the committed size now matches the `ReadFile` length. `VirtualFree(pIoBuffer, 0, MEM_RELEASE)` cleanup is unchanged.
